### PR TITLE
Fixed error "fileType is not a function"

### DIFF
--- a/http-send-multipart-form.js
+++ b/http-send-multipart-form.js
@@ -3,7 +3,7 @@ var mustache = require('mustache'),
 request = require('request'),
 formData = require('form-data'),
 fs = require('fs');
-const fileType = require('file-type');
+const FileType = require('file-type');
 // require in libs
 
 var fileData = ""; // initializing file
@@ -136,11 +136,11 @@ module.exports = function (RED) {
 						buffer = msg.payload.file.data;
 				}
 				
-				var fileTypeInfo = fileType(buffer);
+				var fileTypeInfo = FileType.fromBuffer(buffer);
 				fileMime = fileTypeInfo.mime;
 				fileName += "."+fileTypeInfo.ext;
 
-				if(debug) console.log(fileType(buffer));
+				if(debug) console.log(FileType.fromBuffer(buffer));
 				if(debug) console.log(url);
 
 				if(msg.payload.formOptions !== undefined) {

--- a/package.json
+++ b/package.json
@@ -1,40 +1,38 @@
 {
-	"name": "@ambucher/node-red-contrib-send-form",
-	"version": "0.3.22",
-	"description": "NodeRed node for posting multipart/form-data to http server",
-	"main": "http-send-multipart-form.js",
-	"homepage": "https://github.com/anbucher/node-red-contrib-send-form#readme",
-	"author": 
-	{
-		"name": "ambucher",
-		"email": "npm@ambucher.com",
-		"url": "https://github.com/anbucher"
-	},
-	"scripts": {},
-	"bugs": {
-		"url": "https://github.com/anbucher/node-red-contrib-send-form/issues"
-	},
-	"dependencies": {
-		"file-type": ">=12.4.0",
-		"form-data": ">=3.0.0",
-		"mustache": ">=2.3.0",
-		"request": ">=2.86.0"
-	},
-	"deprecated": false,
-	"keywords": [
-		"node-red",
-		"multipart",
-		"form-data",
-		"http"
-	],
-	"license": "MIT",
-	"node-red": {
-		"nodes": {
-			"http-send-multipart-form": "http-send-multipart-form.js"
-		}
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/anbucher/node-red-contrib-send-form.git"
-	}
+  "name": "@tclayson/node-red-contrib-send-form",
+  "version": "0.0.1",
+  "description": "NodeRed node for posting multipart/form-data to http server",
+  "main": "http-send-multipart-form.js",
+  "homepage": "https://github.com/tclayson/node-red-contrib-send-form#readme",
+  "author": {
+    "name": "tclayson",
+    "url": "https://github.com/tclayson"
+  },
+  "scripts": {},
+  "bugs": {
+    "url": "https://github.com/tclayson/node-red-contrib-send-form/issues"
+  },
+  "dependencies": {
+    "file-type": ">=12.4.0",
+    "form-data": ">=3.0.0",
+    "mustache": ">=2.3.0",
+    "request": ">=2.86.0"
+  },
+  "deprecated": false,
+  "keywords": [
+    "node-red",
+    "multipart",
+    "form-data",
+    "http"
+  ],
+  "license": "MIT",
+  "node-red": {
+    "nodes": {
+      "http-send-multipart-form": "http-send-multipart-form.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tclayson/node-red-contrib-send-form.git"
+  }
 }


### PR DESCRIPTION
This was caused by npm package file-type publishing a breaking change and moving away from a direct function to an object instead.